### PR TITLE
Replace dependency `markdown-it-toc` with `@maboloshi/markdown-it-toc…

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,24 +30,24 @@
   "dependencies": {
     "@vscode/markdown-it-katex": "^1.1.1",
     "hexo-util": "^3.3.0",
-    "markdown-it": "^13.0.2",
-    "markdown-it-abbr": "^1.0.4",
-    "markdown-it-container": "^3.0.0",
-    "markdown-it-deflist": "^2.1.0",
-    "markdown-it-emoji": "^2.0.2",
-    "markdown-it-footnote": "^3.0.3",
-    "markdown-it-ins": "^3.0.1",
-    "markdown-it-mark": "^3.0.1",
-    "markdown-it-sub": "^1.0.0",
-    "markdown-it-sup": "^1.0.0",
-    "markdown-it-toc": "^1.1.0",
+    "markdown-it": "^14.1.0",
+    "markdown-it-abbr": "^2.0.0",
+    "markdown-it-container": "^4.0.0",
+    "markdown-it-deflist": "^3.0.0",
+    "markdown-it-emoji": "^3.0.0",
+    "markdown-it-footnote": "^4.0.0",
+    "markdown-it-ins": "^4.0.0",
+    "markdown-it-mark": "^4.0.0",
+    "markdown-it-sub": "^2.0.0",
+    "markdown-it-sup": "^2.0.0",
+    "@maboloshi/markdown-it-toc": "^1.1.1",
     "markdown-it-toc-and-anchor": "^4.2.0"
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",
-    "@types/node": "^22.10.2",
+    "@types/node": "^22.15.2",
     "hexo": "^7.3.0",
-    "typescript": "^5.7.2",
-    "vitest": "^2.1.8"
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dist"
   ],
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsc",
     "pretest": "npm run build",
     "test": "vitest --no-watch"


### PR DESCRIPTION
…`, and update dependency

@maboloshi/markdown-it-toc has been patched with XSS Vulnerability


我复刻源自[Samchrisinger/Markdown-It-Toc](https://www.npmjs.com/package/markdown-it-toc)（作者已删除了原始存储库），并实施了安全修复。